### PR TITLE
Add ohie.edu.eg domain for Obour High Institute for Engineering and Technology

### DIFF
--- a/lib/domains/eg/edu/ohie.txt
+++ b/lib/domains/eg/edu/ohie.txt
@@ -1,0 +1,2 @@
+معهد العبور العالي للهندسة والتكنولوجيا
+Obour High Institute for Engineering and Technolog


### PR DESCRIPTION
This pull request adds the domain `ohie.edu.eg` to the JetBrains/swot repository.

🔹 **Institution name (English):** Obour High Institute for Engineering and Technology  
🔹 **Institution name (Arabic):** معهد العبور العالي للهندسة والتكنولوجيا  
🔹 **Official website:** https://www.ohie.edu.eg  
🔹 **Proof of domain ownership:** The domain is used officially on the [Contact page](https://www.ohie.edu.eg/contact) and on the homepage.  
🔹 **IT-related long-term programs:** The institute offers accredited 5-year engineering programs including Computer Engineering, which meets JetBrains' requirement for IT-related education.

Please consider adding this domain to allow students and staff access to JetBrains educational licenses. Thank you!
